### PR TITLE
sitemap.js 수정

### DIFF
--- a/sitemap.js
+++ b/sitemap.js
@@ -38,6 +38,7 @@ const main = () => {
       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
         <url>
           <loc>https://blog-nekonyangyee.vercel.app/</loc>
+          <priority>1.00</priority>
         </url>
         ${urls
       .map(({ url, lastmod }) => {
@@ -45,6 +46,7 @@ const main = () => {
               <url>
                 <loc>${url}</loc>
                 <lastmod>${lastmod}</lastmod>
+                <priority>1.00</priority>
               </url>
             `;
       })

--- a/sitemap.js
+++ b/sitemap.js
@@ -38,6 +38,7 @@ const main = () => {
       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
         <url>
           <loc>https://blog-nekonyangyee.vercel.app/</loc>
+          <changefreq>always</changefreq>
           <priority>1.00</priority>
         </url>
         ${urls
@@ -46,7 +47,8 @@ const main = () => {
               <url>
                 <loc>${url}</loc>
                 <lastmod>${lastmod}</lastmod>
-                <priority>1.00</priority>
+                <changefreq>always</changefreq>
+                <priority>0.80</priority>
               </url>
             `;
       })


### PR DESCRIPTION
`sitemap.xm`l에 `changefreq`, `priority`가 지정되어 있지 않아 검색 결과가 노출 될 때 순서가 엉망이 되거나 `Web Master Tool`들이 제대로 크롤링을 하지 못해 검색 결과에 노출되지 않을 수도 있음.